### PR TITLE
Defensive code for choosing current card UIView

### DIFF
--- a/MQSwipingCards/Classes/MQSwipingCardsView.m
+++ b/MQSwipingCards/Classes/MQSwipingCardsView.m
@@ -161,7 +161,7 @@
 #pragma mark - Private
 
 - (UIView *)currentCardView {
-    return self.index <  self.cardViews.count? [self.cardViews objectAtIndex:self.index] : nil;
+    return self.index <  self.cardViews.count? [self.cardViews objectAtIndex:self.index] : [self.cardViews lastObject];
 }
 
 - (void)addPanGestureToView:(UIView *)view withSelector:(SEL)selector{


### PR DESCRIPTION
There appears to be a condition where the `index` property can exceed the number of cards. Might be when a user swips quickly.
